### PR TITLE
REF: remove ArnoldiDecomposition class.

### DIFF
--- a/src/arnoldi/__init__.py
+++ b/src/arnoldi/__init__.py
@@ -1,3 +1,3 @@
 from ._version import __version__
 
-from .decomposition import ArnoldiDecomposition
+from .krylov_schur import partial_schur

--- a/src/arnoldi/decomposition.py
+++ b/src/arnoldi/decomposition.py
@@ -3,42 +3,10 @@ import dataclasses
 import numpy as np
 import numpy.linalg as nlin
 
-from .utils import arg_largest_magnitude, rand_normalized_vector
+from .utils import arg_largest_magnitude
 
 
 norm = nlin.norm
-
-
-class ArnoldiDecomposition:
-    """ Create an arnoldi solver for operators of dimension n, with a Krylov
-    basis of up to m dimensions.
-    """
-    def __init__(self, n, m, dtype=np.complex128):
-        self.n = n
-        self.m = m
-
-        self.V = np.zeros((n, m+1), dtype=dtype)
-        self.H = np.zeros((m+1, m), dtype=dtype)
-
-    @property
-    def _dtype(self):
-        return self.H.dtype
-
-    @property
-    def _atol(self):
-        # Logic of sqrt copied from Julia's ArnoldiMethod.jl package
-        return np.sqrt(np.finfo(self._dtype).eps)
-
-    def initialize(self, init_vector=None):
-        if init_vector is None:
-            init_vector = rand_normalized_vector(self.n, self._dtype)
-        self.V[:, 0] = init_vector
-
-    def iterate(self, A):
-        _, _, m = arnoldi_decomposition(A, self.V, self.H, self._atol)
-        if m != self.m:
-            raise ValueError("Lucky break not supported yet")
-        return m
 
 
 def arnoldi_decomposition(A, V, H, invariant_tol=None, *, start_dim=0, max_dim=None):

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 import scipy.sparse as sp
 
-from arnoldi import ArnoldiDecomposition
 from arnoldi.decomposition import RitzDecomposition, arnoldi_decomposition
 from arnoldi.matrices import mark, laplace
 from arnoldi.utils import rand_normalized_vector
@@ -67,88 +66,6 @@ def assert_invariants(A, V, H, m):
     )
 
     np.testing.assert_allclose(V_m.conj().T @ A @ V_m, H_m, rtol=RTOL, atol=ATOL)
-
-
-class TestArnoldiDecomposition:
-    def test_invariant_simple(self):
-        # Test the invariant A * V ~ V * H, with H Hessenberg matrix and V
-        # orthonormal
-
-        ## Given
-        n = 10
-        m = 6
-        dtype = np.complex128
-
-        A = sp.random(n, n, density=5 / n, dtype=dtype)
-        A += sp.diags_array(np.ones(n))
-
-        ## When
-        arnoldi = ArnoldiDecomposition(n, m)
-        arnoldi.initialize()
-        n_iter = arnoldi.iterate(A)
-
-        V, H = arnoldi.V, arnoldi.H
-
-        ## Then
-        # the arnoldi invariants are respected
-        assert_invariants(A, V, H, n_iter)
-
-    @pytest.mark.flaky(reruns=MAX_RETRIES_SHORT)
-    def test_eigvals_simple(self):
-        # Simple test checking that eigen values of H_k (aka the ritz values)
-        # approximate the matrix's eigenvalues.
-
-        ## Given
-        n = 20
-        # We use large krylov space since basic arnoldi does not converge
-        # quickly. Once we implement restarts, it should converge much faster
-        m = n - 1
-        k = 2
-
-        A = sp.random(n, n, density=5 / n, dtype=np.complex128)
-        # We add ones on the diag to have a well conditioned matrix and eigen
-        # values not too far from 1
-        A += sp.diags_array(np.ones(n))
-
-        r_values = sp.linalg.eigs(A, k)[0]
-
-        ## When
-        arnoldi = ArnoldiDecomposition(n, m)
-        arnoldi.initialize()
-        n_iter = arnoldi.iterate(A)
-
-        ritz = RitzDecomposition.from_v_and_h(arnoldi.V, arnoldi.H, n_iter)
-
-        ## Then
-        # Ensure estimated eigen values approximately match
-        np.testing.assert_allclose(r_values, ritz.values[:k], rtol=RTOL,
-                                   atol=ATOL)
-
-    def test_residuals_computation(self):
-        ## Given
-        n = 20
-        m = 6
-        n_ev = 2
-
-        A = sp.random(n, n, density=5 / n, dtype=np.complex128)
-        # We add ones on the diag to have a well conditioned matrix and eigen
-        # values not too far from 1
-        A += sp.diags_array(np.ones(n))
-
-        ## When
-        arnoldi = ArnoldiDecomposition(n, m)
-        arnoldi.initialize()
-        n_iter = arnoldi.iterate(A)
-
-        ritz = RitzDecomposition.from_v_and_h(arnoldi.V, arnoldi.H, n_ev,
-                                              max_dim=n_iter)
-
-        ## Then
-        # Ensure residuals and approximate residuals match
-        r_residuals = norm(A @ ritz.vectors - ritz.values * ritz.vectors, axis=0)
-
-        residuals = ritz.approximate_residuals
-        np.testing.assert_allclose(r_residuals, residuals, rtol=RTOL, atol=ATOL)
 
 
 class TestArnoldiDecompositionFunction:
@@ -235,13 +152,16 @@ class TestEigenValues:
         A = mark(10)
         n = A.shape[0]
         k = 2
+        dtype = np.complex128
 
         ## When
-        arnoldi = ArnoldiDecomposition(n, m)
-        arnoldi.initialize()
-        arnoldi.iterate(A)
+        V = np.zeros((n, m+1), dtype)
+        H = np.zeros((m+1, m), dtype)
 
-        ritz = RitzDecomposition.from_v_and_h(arnoldi.V, arnoldi.H, k)
+        V[:, 0] = rand_normalized_vector(n, dtype)
+        V, H, _ = arnoldi_decomposition(A, V, H)
+
+        ritz = RitzDecomposition.from_v_and_h(V, H, k)
 
         val = ritz.values[0]
         vec = ritz.vectors[:, 0]
@@ -254,11 +174,15 @@ class TestEigenValues:
 class TestRitzDecomposition:
     def compute_ritz(self, A, m, k, sort_function=None):
         n = A.shape[0]
-        arnoldi = ArnoldiDecomposition(n, m)
-        arnoldi.initialize()
-        arnoldi.iterate(A)
+        dtype = np.complex128
 
-        return RitzDecomposition.from_v_and_h(arnoldi.V, arnoldi.H, k, sort_function=sort_function)
+        V = np.zeros((n, m+1), dtype=dtype)
+        H = np.zeros((m+1, m), dtype=dtype)
+
+        V[:, 0] = rand_normalized_vector(n, dtype)
+
+        V, H, n_iter = arnoldi_decomposition(A, V, H)
+        return RitzDecomposition.from_v_and_h(V, H, k, sort_function=sort_function)
 
     @pytest.mark.parametrize(
         "which, sort_function", [
@@ -311,12 +235,14 @@ class TestRitzDecomposition:
         m = 20
         k = 2
         max_dim = m - 5
+        dtype = np.complex128
 
         ## When
-        arnoldi = ArnoldiDecomposition(n, m)
-        arnoldi.initialize()
-        arnoldi.iterate(A)
-        V, H = arnoldi.V, arnoldi.H
+        V = np.zeros((n, m+1), dtype=dtype)
+        H = np.zeros((m+1, m), dtype=dtype)
+
+        V[:, 0] = rand_normalized_vector(n, dtype)
+        V, H, n_iter = arnoldi_decomposition(A, V, H)
 
         inject_noise(V[:, max_dim:])
         inject_noise(H[max_dim+1:,max_dim:])


### PR DESCRIPTION
Remove `ArnoldiDecomposition` class, which became a useless abstraction on top of `arnoldi_decomposition` function.

We can go back to a class-based solver once the right abstractions around customizable orthonormalization, convergence tracking are done at the lower level for `partial_schur`.